### PR TITLE
GH-2 Fix navigation to selected file (preview)

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,7 @@
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.4-all.zip
+networkTimeout=10000
+validateDistributionUrl=true
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists

--- a/src/main/kotlin/com/me/favourite/directory/FavouriteProjectViewNodeDecorator.kt
+++ b/src/main/kotlin/com/me/favourite/directory/FavouriteProjectViewNodeDecorator.kt
@@ -18,10 +18,6 @@ class FavouriteProjectViewNodeDecorator : ProjectViewNodeDecorator, DumbAware {
         val storage = FavouriteDirectoryStorage.getInstance(node.project)
         if (!storage.isDirectoryFavourite(value.virtualFile)) return
 
-        if (node is MyPsiDirectoryNode) {
-            data.locationString = data.presentableText
-            data.presentableText = data.presentableText?.substringAfterLast("/")
-        }
         data.background = JBColor(
             Color(237, 235, 251, 128),
             Color(71, 39, 60, 60)

--- a/src/main/kotlin/com/me/favourite/directory/FavouriteTreeStructureProvider.kt
+++ b/src/main/kotlin/com/me/favourite/directory/FavouriteTreeStructureProvider.kt
@@ -1,15 +1,23 @@
 package com.me.favourite.directory
 
+import com.intellij.icons.AllIcons
+import com.intellij.ide.projectView.NodeSortOrder
+import com.intellij.ide.projectView.NodeSortSettings
+import com.intellij.ide.projectView.PresentationData
+import com.intellij.ide.projectView.ProjectViewNode
 import com.intellij.ide.projectView.TreeStructureProvider
 import com.intellij.ide.projectView.ViewSettings
-import com.intellij.ide.projectView.impl.nodes.PsiDirectoryNode
+import com.intellij.ide.projectView.impl.nodes.ProjectViewDirectoryHelper
 import com.intellij.ide.util.treeView.AbstractTreeNode
 import com.intellij.openapi.project.DumbAware
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VfsUtil
-import com.intellij.psi.PsiDirectory
-import com.intellij.psi.impl.file.PsiDirectoryFactory
-import com.me.favourite.directory.FavouriteDirectoryStorage.Companion.logger
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.psi.PsiManager
+import com.intellij.ui.JBColor
+import com.intellij.util.ImageLoader
+import com.intellij.util.ui.JBImageIcon
+import java.awt.Color
 import kotlin.io.path.Path
 
 class FavouriteTreeStructureProvider : TreeStructureProvider, DumbAware {
@@ -18,33 +26,64 @@ class FavouriteTreeStructureProvider : TreeStructureProvider, DumbAware {
         children: Collection<AbstractTreeNode<*>>,
         settings: ViewSettings,
     ): Collection<AbstractTreeNode<*>?> {
-        val result = arrayListOf<AbstractTreeNode<*>>()
-        val storage = FavouriteDirectoryStorage.getInstance(parent.project)
-        result.addAll(children.filterNot {
-            it is MyPsiDirectoryNode && it.value.virtualFile.path !in storage.state.directoryPaths
-        })
+        val project = parent.project ?: return children.toList()
+        val result = children.filterNot { it is FavouriteDirectoryNode }.toMutableList()
         if (parent.value is Project) {
-            val directories = createFavouriteDirectories(parent.project, settings)
-            result.addAll(directories)
+            result.addAll(createFavouriteDirectories(project, settings))
         }
         return result
     }
 
-    fun createFavouriteDirectories(project: Project?, viewSettings: ViewSettings): List<PsiDirectoryNode> {
+    fun createFavouriteDirectories(project: Project?, viewSettings: ViewSettings): List<FavouriteDirectoryNode> {
         if (project == null) return emptyList()
         val storage = FavouriteDirectoryStorage.getInstance(project)
-        val directories = storage.state.directoryPaths.mapNotNull {
+        return storage.state.directoryPaths.mapNotNull {
             val directory = VfsUtil.findFile(Path(it), false) ?: return@mapNotNull null
-            logger.debug("Favourite directory: $it")
-            return@mapNotNull PsiDirectoryFactory.getInstance(project).createDirectory(directory)
+            FavouriteDirectoryNode(project, directory, viewSettings)
         }
-        return directories.map { MyPsiDirectoryNode(project, it, viewSettings) }
     }
 }
 
-class MyPsiDirectoryNode(project: Project, value: PsiDirectory, viewSettings: ViewSettings) :
-    PsiDirectoryNode(project, value, viewSettings) {
-    override fun getTypeSortWeight(sortByType: Boolean): Int {
-        return -1
+class FavouriteDirectoryNode(
+    project: Project,
+    directory: VirtualFile,
+    viewSettings: ViewSettings,
+) : ProjectViewNode<VirtualFile>(project, directory, viewSettings) {
+
+    override fun update(presentation: PresentationData) {
+        val vFile = value ?: return
+        presentation.presentableText = vFile.name
+        presentation.locationString = vFile.path
+        presentation.setIcon(createFavouriteIcon())
+        presentation.background = JBColor(
+            Color(237, 235, 251, 128),
+            Color(71, 39, 60, 60)
+        )
+    }
+
+    override fun getChildren(): Collection<AbstractTreeNode<*>> {
+        val project = project ?: return emptyList()
+        val vFile = value ?: return emptyList()
+        val psiDir = PsiManager.getInstance(project).findDirectory(vFile) ?: return emptyList()
+        return ProjectViewDirectoryHelper.getInstance(project)
+            .getDirectoryChildren(psiDir, settings, true)
+    }
+
+    override fun contains(file: VirtualFile): Boolean {
+        val vFile = value ?: return false
+        return VfsUtil.isAncestor(vFile, file, false)
+    }
+
+    override fun getVirtualFile(): VirtualFile? = value
+
+    override fun getSortOrder(settings: NodeSortSettings): NodeSortOrder {
+        return NodeSortOrder.PROJECT_ROOT
+    }
+
+    private fun createFavouriteIcon(): javax.swing.Icon {
+        val imgURL = FavouriteDirectoryStorage::class.java.getResource("/icons/favourite.svg")
+            ?: return AllIcons.Nodes.Folder
+        val image = ImageLoader.loadFromUrl(imgURL) ?: return AllIcons.Nodes.Folder
+        return JBImageIcon(ImageLoader.scaleImage(image, 18, 18))
     }
 }


### PR DESCRIPTION
I had to apply the following changes to the plugin to fix #2. I'm not sure if you're interested in fixing it this way, so I'm just leaving it here as a note - feel free to close it if it's not needed.

With this change, all marked directories are simply placed at the top, so standard navigation in the IDE just works™️ when it jumps to the first occurrence of a file in the file tree.

<img width="65" height="199" alt="image" src="https://github.com/user-attachments/assets/c5522ffd-3a65-4fe9-9b74-8b7bc53a7f32" />